### PR TITLE
Update message-db version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:10.6-alpine
 
 RUN apk add --no-cache curl tar
 RUN mkdir -p /usr/src/eventide \
-  && curl -L https://github.com/message-db/message-db/tarball/v1.1.6 -o /usr/src/eventide/message-db.tgz
+  && curl -L https://github.com/message-db/message-db/archive/refs/tags/v1.2.6.tar.gz -o /usr/src/eventide/message-db.tgz
 RUN tar -xf /usr/src/eventide/message-db.tgz --directory /usr/src/eventide
 
 COPY rundbscripts.sh /docker-entrypoint-initdb.d/

--- a/rundbscripts.sh
+++ b/rundbscripts.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd /usr/src/eventide/message-db-message-db-172b782/database
+cd /usr/src/eventide/message-db-1.2.6/database
 ./install.sh


### PR DESCRIPTION
updating to message-db 1.2.6 in dockerfile and rundbscript

addresses #1 

Also I wasn't sure if you meant to keep postgres version 10, I have this working on postgres:13.3-alpine on my machine.  I figured if you wanted to change pg versions you'd make a separate issue for that so I left that out for now :) 

Hope this helps!  Also happy to make any updates.